### PR TITLE
on windows, do prefixing and split using "\\" delimiter

### DIFF
--- a/minimatch.js
+++ b/minimatch.js
@@ -159,10 +159,10 @@ function make () {
     if (options.matchBase && p.length === 1) return p
     // do prefixing.
     if (options.root && p[0] === "") {
-      return options.root.split("/").concat(p)
+      return options.root.split(process.platform === "win32" ? "\\" : "/").concat(p)
     }
     if (options.cwd && p[0] !== "") {
-      return options.cwd.split("/").concat(p)
+      return options.cwd.split(process.platform === "win32" ? "\\" : "/").concat(p)
     }
     return p
   })


### PR DESCRIPTION
Hi,

I was trying to use miniglob (which is awesome, thank you so much for writing this) on windows and quickly ran into an issue where I couldn't get any results.

It took me hours to nailed it down but it seems like it is due to the prefixing on the set property of minimatch instances.

Without this delimiter check, the set propety was something like `["C:Usersmklabssrcminimatch", {}, "foo.bar"]`. With this little fix, miniglob is now working perfectly on windows too.

You may want to tweak how and where the platform check is done though, since I added the same condition, maybe it should be done once and stored.
