### PR TITLE
Backslashes as path-separators

### DIFF
--- a/minimatch.js
+++ b/minimatch.js
@@ -148,6 +148,12 @@ function Minimatch (pattern, options) {
   if (!options) options = {}
   pattern = pattern.trim()
 
+  // windows: need to use /, not \
+  // On other platforms, \ is a valid (albeit bad) filename char.
+  if (platform === "win32") {
+    pattern = pattern.split("\\").join("/")
+  }
+
   // lru storage.
   // these things aren't particularly big, but walking down the string
   // and turning it into a regexp can get pretty costly.


### PR DESCRIPTION
Jake users on Windows are bumping into this.

Looks like slashes are already being normalized in Minimatch.prototype.match. I just used the same code, and duplicated the comment as well. Not really sure where the appropriate place would be to add a test for this, since it looks like from comments in basic.js that they likely don't run under Windows yet anyhow.
