### PR TITLE
Add option to add support for traditional fnmatch **

### DIFF
--- a/minimatch.js
+++ b/minimatch.js
@@ -210,6 +210,7 @@ function make () {
   // set to the GLOBSTAR object for globstar behavior,
   // and will not contain any / characters
   set = this.globParts = set.map(function (s) {
+    if (options.fnmatchGlobStar) s = s.replace("**", "*/**/*")
     return s.split(slashSplit)
   })
 


### PR DESCRIPTION
This should translate `**` to `*/**/*` when the option `fnmatchGlobStar` is `true`.

I added this to allow matching of globs meant for the Python, Ruby, or C fnmatch libraries.
