### PR TITLE
Fix makeRe(): '{a,b}' shouldn't match 'aaa'

### DIFF
--- a/minimatch.js
+++ b/minimatch.js
@@ -804,7 +804,7 @@ function makeRe () {
 
   // must match entire pattern
   // ending in a * or ** will make it less strict.
-  re = "^" + re + "$"
+  re = "^(?:" + re + ")$"
 
   // can match anything, as long as it's not this.
   if (this.negate) re = "^(?!" + re + ").*$"


### PR DESCRIPTION
Currently, `minimatch.makeRe("{a,b}")` returns `/^a|b$/` which matches not only `a` and `b` but also `axxxx` and `xxxxb`.

`minimatch.makeRe("{a,b}")` should return `/^(?:a|b)$/`.
