### PR TITLE
Exclude dependencies from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
I added a `.gitignore` to prevent `node_modules/` from accidentally being added to git.
