### PR TITLE
Clear stateChar before pipe in extglob

### DIFF
--- a/minimatch.js
+++ b/minimatch.js
@@ -618,6 +618,7 @@ function parse (pattern, isSub) {
           continue
         }
 
+        clearStateChar()
         re += "|"
         continue
 

--- a/test/extglob-ending-with-state-char.js
+++ b/test/extglob-ending-with-state-char.js
@@ -3,5 +3,6 @@ var minimatch = require('../')
 
 test('extglob ending with statechar', function(t) {
   t.notOk(minimatch('ax', 'a?(b*)'))
+  t.ok(minimatch('ax', '?(a*|b)'))
   t.end()
 })


### PR DESCRIPTION
Fixes the same bug as #21 but for special chars at the end of one pattern instead of at the end of the whole pattern list.
