### PR TITLE
Relax minimatch.match about 'option' argument

### DIFF
--- a/minimatch.js
+++ b/minimatch.js
@@ -817,7 +817,7 @@ minimatch.match = function (list, pattern, options) {
   list = list.filter(function (f) {
     return mm.match(f)
   })
-  if (options.nonull && !list.length) {
+  if (mm.options.nonull && !list.length) {
     list.push(pattern)
   }
   return list

--- a/test/defaults.js
+++ b/test/defaults.js
@@ -237,7 +237,7 @@ tap.test("basic tests", function (t) {
 
       var pattern = c[0]
         , expect = c[1].sort(alpha)
-        , options = c[2] || {}
+        , options = c[2]
         , f = c[3] || files
         , tapOpts = c[4] || {}
 


### PR DESCRIPTION
All minimatch API (except minimatch.match)  relaxed about `option` argument.
Fix minimatch.match calling convention please.
