### PR TITLE
Clarify nonull documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Perform a case-insensitive match.
 ### nonull
 
 When a match is not found by `minimatch.match`, return a list containing
-the pattern itself.  When set, an empty list is returned if there are
+the pattern itself.  When not set, an empty list is returned if there are
 no matches.
 
 ### matchBase


### PR DESCRIPTION
The list is empty if `nonull == false` but the documentation stated the opposite.
