### PR TITLE
Look up basename using already split segments

### DIFF
--- a/minimatch.js
+++ b/minimatch.js
@@ -853,7 +853,7 @@ function match (f, partial) {
   var set = this.set
   this.debug(this.pattern, "set", set)
 
-  // Find the basename of the path
+  // Find the basename of the path by looking for the last non-empty segment
   var filename;
   for (var i = f.length - 1; i >= 0; i--) {
     filename = f[i]


### PR DESCRIPTION
Previously path.basename was used in conjunction with joining and splitting the segments array which was much slower than just looking up the basename from the already split segments array.
## Results

Ran the following simple benchmark matching 6 patterns against 100k random strings that contains 5 segments each with the `matchBase` option set to true.

**Results using `path.basename`:** 6 seconds
**Results using lookup in array:** 500 milliseconds

``` js
var paths = [];

for (var i = 0; i < 100000; i++) {
  paths.push('/' + Math.random() + '/' + Math.random() + '/' + Math.random() + '/' + Math.random() + '/' + Math.random())
}

var Minimatch = require('./minimatch').Minimatch;

var patterns = ['a/b/c', 'd/e/f', 'g/e/h', 'i', 'j', 'k'].map(function(pattern) {
  return new Minimatch(pattern, {matchBase: true})
});

var startTime = Date.now()

for (var i = 0 ; i < paths.length; i++) {
  for (var j = 0; j < patterns.length; j++) {
    patterns[j].match(paths[i])
  }
}

console.log(Date.now() - startTime);
```
