### PR TITLE
Fix type for field license, it must be string

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,5 @@
   "devDependencies": {
     "tap": ""
   },
-  "license": {
-    "type": "MIT",
-    "url": "http://github.com/isaacs/minimatch/raw/master/LICENSE"
-  }
+  "license": “MIT”
 }


### PR DESCRIPTION
I checked to validate `package.json` from http://package-json-validator.com/

and see error that

``` json
{
  "errors": [
    "Type for field license, was expected to be string, not object"
  ]
}
```

Reference: https://www.npmjs.org/doc/json.html

Hope to fixes it :octocat: 
