### PR TITLE
node-glob now using minimatch instead of c-binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ A minimal matching utility.
 
 This is the matching library used internally by npm.
 
-Eventually, it will replace the C binding in node-glob.
-
 It works by converting glob expressions into JavaScript `RegExp`
 objects.
 


### PR DESCRIPTION
Unless I'm mistaken, node-glob has remove the c-binding a long time ago in favor of minimatch
