### PR TITLE
Adding browserify -s to generate a UMD bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "pretest": "standard minimatch.js test/*.js",
     "test": "tap test/*.js",
-    "prepublish": "browserify -o browser.js -e minimatch.js --bare"
+    "prepublish": "browserify -o browser.js -e minimatch.js -s minimatch --bare"
   },
   "engines": {
     "node": "*"


### PR DESCRIPTION
Currently, the browser.js artifact generated only works with require calls. Making it UMD will give us broader browser support with AMD and traditional script tags.