### PR TITLE
Add 'allowWindowsEscape' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ Suppress the behavior of treating a leading `!` character as negation.
 Returns from negate expressions the same as if they were not negated.
 (Ie, true on a hit, false on a miss.)
 
+### allowWindowsEscape
+
+Windows path separator `\` is by default converted to `/`, which
+prohibits the usage of `\` as a escape character. This flag skips that
+behavior and allows using the escape character.
 
 ## Comparisons to other fnmatch/glob implementations
 

--- a/minimatch.js
+++ b/minimatch.js
@@ -120,7 +120,7 @@ function Minimatch (pattern, options) {
   pattern = pattern.trim()
 
   // windows support: need to use /, not \
-  if (path.sep !== '/') {
+  if (!options.allowWindowsEscape && path.sep !== '/') {
     pattern = pattern.split(path.sep).join('/')
   }
 
@@ -709,7 +709,7 @@ function match (f, partial) {
   var options = this.options
 
   // windows: need to use /, not \
-  if (path.sep !== '/') {
+  if (!options.allowWindowsEscape && path.sep !== '/') {
     f = f.split(path.sep).join('/')
   }
 


### PR DESCRIPTION
@isaacs This is a minimum PR that fixes #50 #64 https://github.com/isaacs/node-glob/issues/212 and maybe something else.

Since `node-glob` passes the `options` object directly to `minimatch` it shouldn't be necessary to update `node-glob`. It won't break existing code either since by default this flag is `undefined`. Basically if this is set, the caller have to make sure the provided string does not contain `\` for path separator, only for escaping characters.
