### PR TITLE
Explicitly use master branch for Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A minimal matching utility.
 
-[![Build Status](https://secure.travis-ci.org/isaacs/minimatch.svg)](http://travis-ci.org/isaacs/minimatch)
+[![Build Status](https://secure.travis-ci.org/isaacs/minimatch.svg?branch=master)](http://travis-ci.org/isaacs/minimatch)
 
 
 This is the matching library used internally by npm.


### PR DESCRIPTION
Without this, the build badge shows up as failing, for some unknown
reason.