### PR TITLE
Proposal: major release to adopt forward slash, same as node-glob?

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ See:
 * `man 3 fnmatch`
 * `man 5 gitignore`
 
+## Windows
+
+**Please only use forward-slashes in glob expressions.**
+
+Though windows uses either `/` or `\` as its path separator, only `/`
+characters are used by this glob implementation.  You must use
+forward-slashes **only** in glob expressions.  Back-slashes will always
+be interpreted as escape characters, not path separators.
+
 ## Minimatch Class
 
 Create a minimatch object by instantiating the `minimatch.Minimatch` class.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+environment:
+  matrix:
+    - nodejs_version: "7"
+    - nodejs_version: "6"
+    - nodejs_version: "4"
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - set CI=true
+  - npm -g install npm@latest
+  - set PATH=%APPDATA%\npm;%PATH%
+  - npm install
+
+matrix:
+  fast_finish: true
+build: off
+version: '{build}'
+shallow_clone: true
+clone_depth: 1
+
+test_script:
+  - node --version
+  - npm --version
+  - cmd: npm test

--- a/minimatch.js
+++ b/minimatch.js
@@ -1,11 +1,6 @@
 module.exports = minimatch
 minimatch.Minimatch = Minimatch
 
-var path = { sep: '/' }
-try {
-  path = require('path')
-} catch (er) {}
-
 var GLOBSTAR = minimatch.GLOBSTAR = Minimatch.GLOBSTAR = {}
 var expand = require('brace-expansion')
 
@@ -118,11 +113,6 @@ function Minimatch (pattern, options) {
 
   if (!options) options = {}
   pattern = pattern.trim()
-
-  // windows support: need to use /, not \
-  if (path.sep !== '/') {
-    pattern = pattern.split(path.sep).join('/')
-  }
 
   this.options = options
   this.set = []
@@ -707,11 +697,6 @@ function match (f, partial) {
   if (f === '/' && partial) return true
 
   var options = this.options
-
-  // windows: need to use /, not \
-  if (path.sep !== '/') {
-    f = f.split(path.sep).join('/')
-  }
 
   // treat the test path as a set of pathparts.
   f = f.split(slashSplit)


### PR DESCRIPTION
As folks have pointed out before, `minimatch` misbehaves somewhat on Windows -- and it ends up sabotaging the documented usage of `node-glob`, i.e. to ["Please only use forward-slashes in glob expressions"](https://github.com/isaacs/node-glob/#windows).

In the spirit of constructive feedback, I figured I'd submit a PR. The first commit adds Appveyor CI configuration, and causes a bunch of failed tests.

The second removes the substitution of platform-specific path separator -- the assumption being that the caller follows the convention of only using forward-slashes.

Needless to say this would be a breaking change.

Related:
https://github.com/isaacs/minimatch/issues/92
https://github.com/isaacs/minimatch/issues/78
https://github.com/isaacs/minimatch/issues/64
https://github.com/isaacs/minimatch/pull/103
https://github.com/isaacs/node-glob/issues/212