### PR TITLE
Fix bug with escaped '@' in patterns

### DIFF
--- a/minimatch.js
+++ b/minimatch.js
@@ -325,15 +325,21 @@ function parse (pattern, isSub) {
     this.debug('%s\t%s %s %j', pattern, i, re, c)
 
     // skip over any that are escaped.
-    if (escaping && reSpecials[c]) {
-      re += '\\' + c
+    if (escaping) {
+      if (c === '/') { // completely not allowed, even escaped.
+        return false
+      }
+
+      if (reSpecials[c]) {
+        re += '\\'
+      }
+      re += c
       escaping = false
       continue
     }
 
     switch (c) {
       case '/':
-        // completely not allowed, even escaped.
         // Should already be path-split by now.
         return false
 
@@ -415,9 +421,8 @@ function parse (pattern, isSub) {
       continue
 
       case '|':
-        if (inClass || !patternListStack.length || escaping) {
+        if (inClass || !patternListStack.length) {
           re += '\\|'
-          escaping = false
           continue
         }
 
@@ -448,7 +453,6 @@ function parse (pattern, isSub) {
         //  first in the list.  -- POSIX.2 2.8.3.2
         if (i === classStart + 1 || !inClass) {
           re += '\\' + c
-          escaping = false
           continue
         }
 
@@ -485,16 +489,11 @@ function parse (pattern, isSub) {
         // swallow any state char that wasn't consumed
         clearStateChar()
 
-        if (escaping) {
-          // no need
-          escaping = false
-        } else if (reSpecials[c]
-          && !(c === '^' && inClass)) {
+        if (reSpecials[c] && !(c === '^' && inClass)) {
           re += '\\'
         }
 
         re += c
-
     } // switch
   } // for
 

--- a/test/escaping.js
+++ b/test/escaping.js
@@ -1,0 +1,44 @@
+var tap = require('tap')
+var minimatch = require('../')
+
+// test all characters with codes in range [mincc,maxcc]
+var mincc = 0x20
+var maxcc = 0xFF
+// except listed in exceptions array
+var exceptions = ['/', '\\']
+var pre = 'x'  // prepended to the testable character
+var post = 'y' // appended to the testable character
+
+function escapeChar (cc) {
+  return '"\\u' + ('000' + cc.toString(16).toUpperCase()).substr(-4) + '"'
+}
+
+tap.test('escaping tests', function (t) {
+  for (var cc = mincc; cc <= maxcc; ++cc) {
+    var cp = String.fromCharCode(cc)
+    if (exceptions.indexOf(cp) === -1) {
+      var str = pre + cp + post
+      var pattern = '*\\' + cp + '*'
+      var msg = JSON.stringify(str) +
+        ' (for codepoint ' + escapeChar(cc) + ')' +
+        ' should match pattern ' + JSON.stringify(pattern)
+      t.equal(minimatch(str, pattern), true, msg)
+    }
+  }
+  t.end()
+})
+
+tap.test('class escaping tests', function (t) {
+  for (var cc = mincc; cc <= maxcc; ++cc) {
+    var cp = String.fromCharCode(cc)
+    if (exceptions.indexOf(cp) === -1) {
+      var str = pre + cp + post
+      var pattern = '*[\\' + cp + ']*'
+      var msg = JSON.stringify(str) +
+        ' (for codepoint ' + escapeChar(cc) + ')' +
+        ' should match pattern ' + JSON.stringify(pattern)
+      t.equal(minimatch(str, pattern), true, msg)
+    }
+  }
+  t.end()
+})


### PR DESCRIPTION
For example,
`
  minimatch('@', '\\@*')
`
was returns `false` when `true` expected