### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/minimatch.js
+++ b/minimatch.js
@@ -238,7 +238,7 @@ class Minimatch {
       negateOffset++
     }
 
-    if (negateOffset) this.pattern = pattern.substr(negateOffset)
+    if (negateOffset) this.pattern = pattern.slice(negateOffset)
     this.negate = negate
   }
 
@@ -614,7 +614,7 @@ class Minimatch {
           } catch (er) {
             // not a valid class!
             sp = this.parse(cs, SUBPARSE)
-            re = re.substr(0, reClassStart) + '\\[' + sp[0] + '\\]'
+            re = re.substring(0, reClassStart) + '\\[' + sp[0] + '\\]'
             hasMagic = hasMagic || sp[1]
             inClass = false
             continue
@@ -647,9 +647,9 @@ class Minimatch {
       // this is a huge pita.  We now have to re-walk
       // the contents of the would-be class to re-translate
       // any characters that were passed through as-is
-      cs = pattern.substr(classStart + 1)
+      cs = pattern.slice(classStart + 1)
       sp = this.parse(cs, SUBPARSE)
-      re = re.substr(0, reClassStart) + '\\[' + sp[0]
+      re = re.substring(0, reClassStart) + '\\[' + sp[0]
       hasMagic = hasMagic || sp[1]
     }
 

--- a/test/escaping.js
+++ b/test/escaping.js
@@ -10,7 +10,7 @@ var pre = 'x'  // prepended to the testable character
 var post = 'y' // appended to the testable character
 
 function escapeChar (cc) {
-  return '"\\u' + ('000' + cc.toString(16).toUpperCase()).substr(-4) + '"'
+  return '"\\u' + ('000' + cc.toString(16).toUpperCase()).slice(-4) + '"'
 }
 
 tap.test('escaping tests', function (t) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) or [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) which work similarily but aren't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.