### PR TITLE
fix: bundling library using webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/mjs/index.js",
-        "types": "./dist/mjs/index.d.ts"
+        "types": "./dist/mjs/index.d.ts",
+        "default": "./dist/mjs/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   },


### PR DESCRIPTION
this change ensures "default" conditions are last, fixing the following webpack bundling error (on import to lib):
```
Module not found: Error: Default condition should be last one
```