### PR TITLE
Remove third occurence of process.platform

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -309,7 +309,7 @@ export class Minimatch {
   nocase: boolean
 
   isWindows: boolean
-  platform: typeof process.platform
+  platform: Platform
   windowsNoMagicRoot: boolean
 
   regexp: false | null | MMRegExp


### PR DESCRIPTION
Seems like on of the occurences of `process.platform` was missed, thought I'd just go ahead and do a PR instead of commenting in the issue again :)