### PR TITLE
Webcontainer Fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,7 +174,7 @@ export const defaults = (def: MinimatchOptions): typeof minimatch => {
       }
     },
 
-    AST: class AST extends orig.AST {
+    AST: class AST2 extends orig.AST {
       /* c8 ignore start */
       constructor(
         type: ExtglobType | null,


### PR DESCRIPTION
Hi,

I'm a huge fan of your glob package! I'm trying to make my stuff work in StackBlitz/WebContainers and there is a weird bug with minimatch.

I found a way to fix it, but I cannot explain why or how it currently throws an error.

## To Reproduce
[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/isaacs/minimatch)

and run

```
npm run prepare && \
    node -e "const fs = require('fs'); \
        const packageJSON = JSON.parse(fs.readFileSync('package.json').toString()); \
        packageJSON.type = 'module'; \
        fs.writeFileSync('package.json', JSON.stringify(packageJSON, null, 2));" && \
    node dist/mjs/index.js
```
> we're adding `"type": "module"` in `package.json` to run as module

Here's the error thrown
```
SyntaxError: Unexpected token '.'
    at __global_eval__ (https://wmaijygzvgithub-qfee.w-credentialless.staticblitz.com/blitz.bf38680a.js:1:267)
    at _0x49076a (https://wmaijygzvgithub-qfee.w-credentialless.staticblitz.com/blitz.bf38680a.js:44:149088)
    at _0x23bfe7._compile (https://wmaijygzvgithub-qfee.w-credentialless.staticblitz.com/blitz.bf38680a.js:44:147590)
    at _0x5b3f55.instantiate (https://wmaijygzvgithub-qfee.w-credentialless.staticblitz.com/blitz.bf38680a.js:44:306904)
    at _0x8a4b23._instantiate (https://wmaijygzvgithub-qfee.w-credentialless.staticblitz.com/blitz.bf38680a.js:44:311409)
    at _0x8a4b23.instantiate (https://wmaijygzvgithub-qfee.w-credentialless.staticblitz.com/blitz.bf38680a.js:44:309815)
    at ModuleJob._instantiate (https://wmaijygzvgithub-qfee.w-credentialless.staticblitz.com/blitz.bf38680a.js:35:1077213)
    at async ModuleJob.run (https://wmaijygzvgithub-qfee.w-credentialless.staticblitz.com/blitz.bf38680a.js:35:1078031)
    at async Promise.all (index 0)
    at async ESMLoader.import (https://wmaijygzvgithub-qfee.w-credentialless.staticblitz.com/blitz.bf38680a.js:35:1312912)
```

### Try with the fix
[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/cplepage/minimatch)

and run

```
npm run prepare && \
    node -e "const fs = require('fs'); \
        const packageJSON = JSON.parse(fs.readFileSync('package.json').toString()); \
        packageJSON.type = 'module'; \
        fs.writeFileSync('package.json', JSON.stringify(packageJSON, null, 2));" && \
    node dist/mjs/index.js
```

No error is thrown


The issue is also open on WebContainer-core repo : https://github.com/stackblitz/webcontainer-core/issues/1097

I really wish we could have more detailed investigation from any member/collaborator at StackBlitz and WebContainers.
Although, I hope my weird and ugly fix doesn't break anything depending on this. The test are all passing in both situations, but I have no idea what could depend on that class naming. 

If there's anything we can do, please let me know so we can all enjoy keeping glob as a dependency in our stackblitz shared project. 

### Glob now working as expected

[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/edit/minimatch-fix)