### PR TITLE
feat: env var __MINIMATCH_NO_FASTTEST__=1 disables fastTest

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -129,6 +129,15 @@ minimatch.sep = sep
 export const GLOBSTAR = Symbol('globstar **')
 minimatch.GLOBSTAR = GLOBSTAR
 
+const noFastTest: boolean = (
+  typeof process === 'object' && process
+    ? (typeof process.env === 'object' &&
+        process.env &&
+        process.env.__MINIMATCH_NO_FASTTEST__ === '1') ||
+      false
+    : false
+)
+
 // any single thing other than /
 // don't need to escape / when using new RegExp()
 const qmark = '[^/]'
@@ -980,7 +989,10 @@ export class Minimatch {
     // *, *.*, and *.<ext>  Add a fast check method for those.
     let m: RegExpMatchArray | null
     let fastTest: null | ((f: string) => boolean) = null
-    if ((m = pattern.match(starRE))) {
+
+    if (noFastTest) {
+      fastTest = null
+    } else if ((m = pattern.match(starRE))) {
       fastTest = options.dot ? starTestDot : starTest
     } else if ((m = pattern.match(starDotExtRE))) {
       fastTest = (


### PR DESCRIPTION
The optimized fastTests for common patterns work by overwriting the `test` property on a `RegExp` instance. This can cause issues in some locked down runtime environments or trip up static analysis tools.

This proposes allowing short-circuiting and disable the optimizations by setting environment variable `__MINIMATCH_NO_FASTTEST__` (open for naming suggestions) to `1`.

I opted for an environment variable rather than an API change because this is more likely to be relevant for end software operators rather than authors of depending software. Might also be useful for debugging minimatch itself (#215).