### PR TITLE
fix: override with fastTest as property on regex object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1009,7 +1009,15 @@ export class Minimatch {
     }
 
     const re = AST.fromGlob(pattern, this.options).toMMPattern()
-    return fastTest ? Object.assign(re, { test: fastTest }) : re
+    if (fastTest) {
+      if (typeof re === 'object') {
+        // Avoids overriding in frozen environments
+        Reflect.defineProperty(re, 'test', { value: fastTest })
+      } else {
+        Object.assign(re, { test: fastTest })
+      }
+    }
+    return re
   }
 
   makeRe() {


### PR DESCRIPTION
The optimized fastTests for common patterns work by overwriting the `test` property on a `RegExp` instance. This can cause issues in some locked down runtime environments or trip up static analysis tools.


This uses `defineProperty` to override the `test` property on the RegExp instance instead.