### PR TITLE
fix: duplicated patterns in second phase preprocess loop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -675,9 +675,11 @@ export class Minimatch {
           globParts[j],
           !this.preserveMultipleSlashes
         )
-        if (!matched) continue
-        globParts[i] = matched
-        globParts[j] = []
+        if (matched) {
+          globParts[i] = []
+          globParts[j] = matched
+          break
+        }
       }
     }
     return globParts.filter(gs => gs.length)

--- a/tap-snapshots/test/optimization-level-2.ts.test.cjs
+++ b/tap-snapshots/test/optimization-level-2.ts.test.cjs
@@ -4510,6 +4510,78 @@ Array [
 ]
 `
 
+exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and optimization > linux > {*,a,b} > defaults 1`] = `
+Array [
+  Array [
+    "*",
+  ],
+]
+`
+
+exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and optimization > linux > {*,a,b} > multislash 1`] = `
+Array [
+  Array [
+    "*",
+  ],
+]
+`
+
+exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and optimization > linux > {*,a,b} > no globstar 1`] = `
+Array [
+  Array [
+    "*",
+  ],
+]
+`
+
+exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and optimization > linux > {a,*,b} > defaults 1`] = `
+Array [
+  Array [
+    "*",
+  ],
+]
+`
+
+exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and optimization > linux > {a,*,b} > multislash 1`] = `
+Array [
+  Array [
+    "*",
+  ],
+]
+`
+
+exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and optimization > linux > {a,*,b} > no globstar 1`] = `
+Array [
+  Array [
+    "*",
+  ],
+]
+`
+
+exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and optimization > linux > {a,b,*} > defaults 1`] = `
+Array [
+  Array [
+    "*",
+  ],
+]
+`
+
+exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and optimization > linux > {a,b,*} > multislash 1`] = `
+Array [
+  Array [
+    "*",
+  ],
+]
+`
+
+exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and optimization > linux > {a,b,*} > no globstar 1`] = `
+Array [
+  Array [
+    "*",
+  ],
+]
+`
+
 exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and optimization > linux > {a/**/b,a/b} > defaults 1`] = `
 Array [
   Array [
@@ -5834,6 +5906,78 @@ exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and op
 Array [
   Array [
     ".",
+  ],
+]
+`
+
+exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and optimization > win32 > {*,a,b} > defaults 1`] = `
+Array [
+  Array [
+    "*",
+  ],
+]
+`
+
+exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and optimization > win32 > {*,a,b} > multislash 1`] = `
+Array [
+  Array [
+    "*",
+  ],
+]
+`
+
+exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and optimization > win32 > {*,a,b} > no globstar 1`] = `
+Array [
+  Array [
+    "*",
+  ],
+]
+`
+
+exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and optimization > win32 > {a,*,b} > defaults 1`] = `
+Array [
+  Array [
+    "*",
+  ],
+]
+`
+
+exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and optimization > win32 > {a,*,b} > multislash 1`] = `
+Array [
+  Array [
+    "*",
+  ],
+]
+`
+
+exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and optimization > win32 > {a,*,b} > no globstar 1`] = `
+Array [
+  Array [
+    "*",
+  ],
+]
+`
+
+exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and optimization > win32 > {a,b,*} > defaults 1`] = `
+Array [
+  Array [
+    "*",
+  ],
+]
+`
+
+exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and optimization > win32 > {a,b,*} > multislash 1`] = `
+Array [
+  Array [
+    "*",
+  ],
+]
+`
+
+exports[`test/optimization-level-2.ts > TAP > explicit pattern coalescing and optimization > win32 > {a,b,*} > no globstar 1`] = `
+Array [
+  Array [
+    "*",
   ],
 ]
 `

--- a/test/optimization-level-2.ts
+++ b/test/optimization-level-2.ts
@@ -60,6 +60,9 @@ t.test('explicit pattern coalescing and optimization', t => {
         './x/.././///.//./',
         '*/../**',
         '*/../**/?/*/[a-z]',
+        '{*,a,b}',
+        '{a,*,b}',
+        '{a,b,*}',
       ]
 
       const exp = (p: string) => braceExpand(p).map(s => s.split('/'))


### PR DESCRIPTION
This patch removes a potential duplication in the level 2 optimization.

To reproduce, evaluate following:
```
new Minimatch("{a,b,*}", {optimizationLevel: 2})
```

Current upstream has an extra "b" in `set` and `globParts`:
```
Minimatch {
  options: { optimizationLevel: 2 },
  set: [ [ /^(?!\.)[^/]+?$/ ], [ 'b' ] ],
  pattern: '{a,b,*}',
  windowsPathsNoEscape: false,
  nonegate: false,
  negate: false,
  comment: false,
  empty: false,
  preserveMultipleSlashes: false,
  partial: false,
  globSet: [ 'a', 'b', '*' ],
  globParts: [ [ '*' ], [ 'b' ] ],
  nocase: false,
  isWindows: false,
  platform: 'darwin',
  windowsNoMagicRoot: false,
  regexp: null
}
```

This patch:
```
Minimatch {
  options: { optimizationLevel: 2 },
  set: [ [ /^(?!\.)[^/]+?$/ ] ],
  pattern: '{a,b,*}',
  windowsPathsNoEscape: false,
  nonegate: false,
  negate: false,
  comment: false,
  empty: false,
  preserveMultipleSlashes: false,
  partial: false,
  globSet: [ 'a', 'b', '*' ],
  globParts: [ [ '*' ] ],
  nocase: false,
  isWindows: false,
  platform: 'darwin',
  windowsNoMagicRoot: false,
  regexp: null
}
```