### PR TITLE
docs: fix typo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -798,7 +798,7 @@ export class Minimatch {
     }
 
     // resolve and reduce . and .. portions in the file as well.
-    // dont' need to do the second phase, because it's only one string[]
+    // don't need to do the second phase, because it's only one string[]
     const { optimizationLevel = 1 } = this.options
     if (optimizationLevel >= 2) {
       file = this.levelTwoFileOptimize(file)


### PR DESCRIPTION
Was investigating the `partial` option to try and port it to `picomatch`, and I came across this comment. Might be a extremely tiny PR but it definitely fixes a typo :-)