### PR TITLE
Support `magicalBraces` option in escape/unescape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /dist
 /coverage
 /node_modules
+/.tap
+/.tshy
+/.tshy-build

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "presnap": "npm run prepare",
     "test": "tap",
     "snap": "tap",
-    "format": "prettier --write . --loglevel warn",
+    "format": "prettier --write . --log-level warn",
     "benchmark": "node benchmark/index.js",
     "typedoc": "typedoc --tsconfig tsconfig-esm.json ./src/*.ts"
   },

--- a/src/escape.ts
+++ b/src/escape.ts
@@ -7,16 +7,25 @@ import { MinimatchOptions } from './index.js'
  * a magic character wrapped in a character class can only be satisfied by
  * that exact character.  In this mode, `\` is _not_ escaped, because it is
  * not interpreted as a magic character, but instead as a path separator.
+ *
+ * If the {@link magicalBraces | GlobOptions.magicalBraces} option is used,
+ * then braces (`{` and `}`) will be escaped.
  */
 export const escape = (
   s: string,
   {
     windowsPathsNoEscape = false,
-  }: Pick<MinimatchOptions, 'windowsPathsNoEscape'> = {}
+    magicalBraces = false,
+  }: Pick<MinimatchOptions, 'windowsPathsNoEscape' | 'magicalBraces'> = {},
 ) => {
   // don't need to escape +@! because we escape the parens
   // that make those magic, and escaping ! as [!] isn't valid,
   // because [!]] is a valid glob class meaning not ']'.
+  if (magicalBraces) {
+    return windowsPathsNoEscape
+      ? s.replace(/[?*()[\]{}]/g, '[$&]')
+      : s.replace(/[?*()[\]\\{}]/g, '\\$&')
+  }
   return windowsPathsNoEscape
     ? s.replace(/[?*()[\]]/g, '[$&]')
     : s.replace(/[?*()[\]\\]/g, '\\$&')

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,12 +192,12 @@ export const defaults = (def: MinimatchOptions): typeof minimatch => {
 
     unescape: (
       s: string,
-      options: Pick<MinimatchOptions, 'windowsPathsNoEscape'> = {}
+      options: Pick<MinimatchOptions, 'windowsPathsNoEscape' | 'magicalBraces'> = {}
     ) => orig.unescape(s, ext(def, options)),
 
     escape: (
       s: string,
-      options: Pick<MinimatchOptions, 'windowsPathsNoEscape'> = {}
+      options: Pick<MinimatchOptions, 'windowsPathsNoEscape' | 'magicalBraces'> = {}
     ) => orig.escape(s, ext(def, options)),
 
     filter: (pattern: string, options: MinimatchOptions = {}) =>

--- a/src/unescape.ts
+++ b/src/unescape.ts
@@ -2,24 +2,37 @@ import { MinimatchOptions } from './index.js'
 /**
  * Un-escape a string that has been escaped with {@link escape}.
  *
- * If the {@link windowsPathsNoEscape} option is used, then square-brace
+ * If the {@link windowsPathsNoEscape} option is used, then square-bracket
  * escapes are removed, but not backslash escapes.  For example, it will turn
  * the string `'[*]'` into `*`, but it will not turn `'\\*'` into `'*'`,
- * becuase `\` is a path separator in `windowsPathsNoEscape` mode.
+ * because `\` is a path separator in `windowsPathsNoEscape` mode.
  *
- * When `windowsPathsNoEscape` is not set, then both brace escapes and
+ * When `windowsPathsNoEscape` is not set, then both square-bracket escapes and
  * backslash escapes are removed.
  *
  * Slashes (and backslashes in `windowsPathsNoEscape` mode) cannot be escaped
  * or unescaped.
+ *
+ * When `magicalBraces` is not set, escapes of braces (`{` and `}`) will not be
+ * unescaped.
  */
 export const unescape = (
   s: string,
   {
     windowsPathsNoEscape = false,
-  }: Pick<MinimatchOptions, 'windowsPathsNoEscape'> = {}
+    magicalBraces = true,
+  }: Pick<MinimatchOptions, 'windowsPathsNoEscape' | 'magicalBraces'> = {},
 ) => {
+  if (magicalBraces) {
+    return windowsPathsNoEscape
+      ? s.replace(/\[([^\/\\])\]/g, '$1')
+      : s
+          .replace(/((?!\\).|^)\[([^\/\\])\]/g, '$1$2')
+          .replace(/\\([^\/])/g, '$1')
+  }
   return windowsPathsNoEscape
-    ? s.replace(/\[([^\/\\])\]/g, '$1')
-    : s.replace(/((?!\\).|^)\[([^\/\\])\]/g, '$1$2').replace(/\\([^\/])/g, '$1')
+    ? s.replace(/\[([^\/\\{}])\]/g, '$1')
+    : s
+        .replace(/((?!\\).|^)\[([^\/\\{}])\]/g, '$1$2')
+        .replace(/\\([^\/{}])/g, '$1')
 }

--- a/test/escape-has-magic.js
+++ b/test/escape-has-magic.js
@@ -14,7 +14,7 @@ for (const p of patterns) {
       windowsPathsNoEscape: true,
     }),
     pattern,
-    'win32 unescape(' + pattern + ')'
+    'win32 unescape(' + pattern + ')',
   )
   const mmp = new Minimatch(escapep, { ...opts, nocaseMagicOnly: true })
   const mmw = new Minimatch(escapew, {
@@ -34,3 +34,41 @@ t.equal(unescape('[\\]'), '[]')
 
 t.equal(new Minimatch('{a,b}').hasMagic(), false)
 t.equal(new Minimatch('{a,b}', { magicalBraces: true }).hasMagic(), true)
+
+/** @type {[string, string, { magicalBraces: boolean, windowsPathsNoEscape: boolean }][]} */
+const bracedEscapeTests = [
+  ['{a,b}', '\\{a,b\\}', { magicalBraces: true, windowsPathsNoEscape: false }],
+  ['{a,b}', '[{]a,b[}]', { magicalBraces: true, windowsPathsNoEscape: true }],
+  ['[{]', '\\[\\{\\]', { magicalBraces: true, windowsPathsNoEscape: false }],
+  ['[{]', '[[][{][]]', { magicalBraces: true, windowsPathsNoEscape: true }],
+  [
+    '[\\{]',
+    '\\[\\\\\\{\\]',
+    { magicalBraces: true, windowsPathsNoEscape: false },
+  ],
+  ['[\\{]', '[[]\\[{][]]', { magicalBraces: true, windowsPathsNoEscape: true }],
+
+  ['{a,b}', '{a,b}', { magicalBraces: false, windowsPathsNoEscape: false }],
+  ['{a,b}', '{a,b}', { magicalBraces: false, windowsPathsNoEscape: true }],
+  ['[{]', '\\[{\\]', { magicalBraces: false, windowsPathsNoEscape: false }],
+  ['[{]', '[[]{[]]', { magicalBraces: false, windowsPathsNoEscape: true }],
+  [
+    '[\\{]',
+    '\\[\\\\{\\]',
+    { magicalBraces: false, windowsPathsNoEscape: false },
+  ],
+  ['[\\{]', '[[]\\{[]]', { magicalBraces: false, windowsPathsNoEscape: true }],
+]
+
+for (const [pattern, escaped, opts] of bracedEscapeTests) {
+  t.equal(
+    escape(pattern, opts),
+    escaped,
+    JSON.stringify({ pattern, escaped, opts }),
+  )
+  t.equal(
+    unescape(escaped, opts),
+    pattern,
+    JSON.stringify({ pattern, escaped, opts }),
+  )
+}


### PR DESCRIPTION
Resolves #234

---

I ran across this question, so was going to give implementing it a shot... I got stuck in the tests. Adding additional tests to the patterns array seems like what I *should* do, so I tried to figure out what the type of that should be. It appears it should be:

```ts
type Patterns =
  /** Comment */
  | string
  /** Modifier for files */
  | (() => void)
  /** Test case */
  | [
      pattern: string,
      expect: string[],
      options?: import("minimatch").MinimatchOptions | null,
      files?: string[],
      tapOptions?: import("@tapjs/core").Extra,
    ];
```

But tossing that type into a [`@satisfies`](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#satisfies) tag on the variable reveals that 16 of the test cases specify `{ null: true }` for options, but `MinimatchOptions` expects the key `nonull`, not `null`. At this point I gave up and just didn't use it for the new test cases.