### PR TITLE
brace-expansion Regular Expression Denial of Service vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "node": "20 || >=22"
   },
   "devDependencies": {
-    "@types/brace-expansion": "^1.1.2",
+    "@types/brace-expansion": "^1.1.12",
     "@types/node": "^24.0.0",
     "mkdirp": "^3.0.1",
     "prettier": "^3.3.2",


### PR DESCRIPTION
A vulnerability was found in juliangruber brace-expansion up to 1.1.11/2.0.1/3.0.0/4.0.0. It has been rated as problematic. Affected by this issue is the function expand of the file index.js. The manipulation leads to inefficient regular expression complexity. The attack may be launched remotely. The complexity of an attack is rather high. The exploitation is known to be difficult. The exploit has been disclosed to the public and may be used. Upgrading to version 1.1.12, 2.0.2, 3.0.1 and 4.0.1 is able to address this issue. The name of the patch is a5b98a4f30d7813266b221435e1eaaf25a1b0ac5. It is recommended to upgrade the affected component.

Package: brace-expansion (npm)

Affected versions : >= 1.0.0, <= 1.1.11
Patched version : 1.1.12
