### PR TITLE
fix: remove invalid unicode escapes from regExpEscape

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -166,8 +166,12 @@ const addPatternStart = new Set(['[', '.'])
 // cases where traversal is A-OK, no dot prevention needed
 const justDots = new Set(['..', '.'])
 const reSpecials = new Set('().*{}+?[]^$\\!')
+// Characters that need escaping in a regexp, and are valid to escape with
+// backslash in unicode mode. Characters like ,#- and whitespace are NOT
+// valid to escape in unicode mode, and don't need escaping anyway since
+// they're not regexp metacharacters outside of character classes.
 const regExpEscape = (s: string) =>
-  s.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
+  s.replace(/[[\]{}()*+?.\\^$|]/g, '\\$&')
 
 // any single thing other than /
 const qmark = '[^/]'

--- a/tap-snapshots/test/basic.js.test.cjs
+++ b/tap-snapshots/test/basic.js.test.cjs
@@ -3464,11 +3464,11 @@ exports[`test/basic.js > TAP > basic tests > makeRe ?.js 4`] = `
 `
 
 exports[`test/basic.js > TAP > basic tests > makeRe ?(x-!(y)|z) 1`] = `
-/^(?:x\\-(?:(?!(?:y(?:$|\\/)))[^/]*?)|z)?$/
+/^(?:x-(?:(?!(?:y(?:$|\\/)))[^/]*?)|z)?$/
 `
 
 exports[`test/basic.js > TAP > basic tests > makeRe ?(x-!(y)|z)b 1`] = `
-/^(?:x\\-(?:(?!(?:yb(?:$|\\/)))[^/]*?)|z)?b$/
+/^(?:x-(?:(?!(?:yb(?:$|\\/)))[^/]*?)|z)?b$/
 `
 
 exports[`test/basic.js > TAP > basic tests > makeRe ?***?**** 1`] = `
@@ -3636,7 +3636,7 @@ exports[`test/basic.js > TAP > basic tests > makeRe [\\z-a] 1`] = `
 `
 
 exports[`test/basic.js > TAP > basic tests > makeRe [#a* 1`] = `
-/^\\[\\#a[^/]*?$/
+/^\\[#a[^/]*?$/
 `
 
 exports[`test/basic.js > TAP > basic tests > makeRe [^a-c]* 1`] = `
@@ -3940,7 +3940,7 @@ false
 `
 
 exports[`test/basic.js > TAP > basic tests > makeRe #* 1`] = `
-/^\\#[^/]*?$/
+/^#[^/]*?$/
 `
 
 exports[`test/basic.js > TAP > basic tests > makeRe +(?) 1`] = `

--- a/tap-snapshots/test/escape-has-magic.js.test.cjs
+++ b/tap-snapshots/test/escape-has-magic.js.test.cjs
@@ -229,7 +229,7 @@ exports[`test/escape-has-magic.js > TAP > ?(x-!(y)|z) 1`] = `
 Array [
   Array [
     Array [
-      /^(?:x\\-(?:(?!(?:y(?:$|\\/)))[^/]*?)|z)?$/,
+      /^(?:x-(?:(?!(?:y(?:$|\\/)))[^/]*?)|z)?$/,
     ],
   ],
   true,
@@ -240,7 +240,7 @@ exports[`test/escape-has-magic.js > TAP > ?(x-!(y)|z)b 1`] = `
 Array [
   Array [
     Array [
-      /^(?:x\\-(?:(?!(?:yb(?:$|\\/)))[^/]*?)|z)?b$/,
+      /^(?:x-(?:(?!(?:yb(?:$|\\/)))[^/]*?)|z)?b$/,
     ],
   ],
   true,
@@ -724,7 +724,7 @@ exports[`test/escape-has-magic.js > TAP > [#a* 1`] = `
 Array [
   Array [
     Array [
-      /^\\[\\#a[^/]*?$/,
+      /^\\[#a[^/]*?$/,
     ],
   ],
   true,
@@ -1611,7 +1611,7 @@ exports[`test/escape-has-magic.js > TAP > #* 1`] = `
 Array [
   Array [
     Array [
-      /^\\#[^/]*?$/,
+      /^#[^/]*?$/,
     ],
   ],
   true,

--- a/tap-snapshots/test/optimization-level-0.ts.test.cjs
+++ b/tap-snapshots/test/optimization-level-0.ts.test.cjs
@@ -3464,11 +3464,11 @@ exports[`test/optimization-level-0.ts > TAP > basic tests > makeRe ?.js 4`] = `
 `
 
 exports[`test/optimization-level-0.ts > TAP > basic tests > makeRe ?(x-!(y)|z) 1`] = `
-/^(?:x\\-(?:(?!(?:y(?:$|\\/)))[^/]*?)|z)?$/
+/^(?:x-(?:(?!(?:y(?:$|\\/)))[^/]*?)|z)?$/
 `
 
 exports[`test/optimization-level-0.ts > TAP > basic tests > makeRe ?(x-!(y)|z)b 1`] = `
-/^(?:x\\-(?:(?!(?:yb(?:$|\\/)))[^/]*?)|z)?b$/
+/^(?:x-(?:(?!(?:yb(?:$|\\/)))[^/]*?)|z)?b$/
 `
 
 exports[`test/optimization-level-0.ts > TAP > basic tests > makeRe ?***?**** 1`] = `
@@ -3636,7 +3636,7 @@ exports[`test/optimization-level-0.ts > TAP > basic tests > makeRe [\\z-a] 1`] =
 `
 
 exports[`test/optimization-level-0.ts > TAP > basic tests > makeRe [#a* 1`] = `
-/^\\[\\#a[^/]*?$/
+/^\\[#a[^/]*?$/
 `
 
 exports[`test/optimization-level-0.ts > TAP > basic tests > makeRe [^a-c]* 1`] = `
@@ -3940,7 +3940,7 @@ false
 `
 
 exports[`test/optimization-level-0.ts > TAP > basic tests > makeRe #* 1`] = `
-/^\\#[^/]*?$/
+/^#[^/]*?$/
 `
 
 exports[`test/optimization-level-0.ts > TAP > basic tests > makeRe +(?) 1`] = `

--- a/tap-snapshots/test/optimization-level-2.ts.test.cjs
+++ b/tap-snapshots/test/optimization-level-2.ts.test.cjs
@@ -3464,11 +3464,11 @@ exports[`test/optimization-level-2.ts > TAP > basic tests > makeRe ?.js 4`] = `
 `
 
 exports[`test/optimization-level-2.ts > TAP > basic tests > makeRe ?(x-!(y)|z) 1`] = `
-/^(?:x\\-(?:(?!(?:y(?:$|\\/)))[^/]*?)|z)?$/
+/^(?:x-(?:(?!(?:y(?:$|\\/)))[^/]*?)|z)?$/
 `
 
 exports[`test/optimization-level-2.ts > TAP > basic tests > makeRe ?(x-!(y)|z)b 1`] = `
-/^(?:x\\-(?:(?!(?:yb(?:$|\\/)))[^/]*?)|z)?b$/
+/^(?:x-(?:(?!(?:yb(?:$|\\/)))[^/]*?)|z)?b$/
 `
 
 exports[`test/optimization-level-2.ts > TAP > basic tests > makeRe ?***?**** 1`] = `
@@ -3636,7 +3636,7 @@ exports[`test/optimization-level-2.ts > TAP > basic tests > makeRe [\\z-a] 1`] =
 `
 
 exports[`test/optimization-level-2.ts > TAP > basic tests > makeRe [#a* 1`] = `
-/^\\[\\#a[^/]*?$/
+/^\\[#a[^/]*?$/
 `
 
 exports[`test/optimization-level-2.ts > TAP > basic tests > makeRe [^a-c]* 1`] = `
@@ -3940,7 +3940,7 @@ false
 `
 
 exports[`test/optimization-level-2.ts > TAP > basic tests > makeRe #* 1`] = `
-/^\\#[^/]*?$/
+/^#[^/]*?$/
 `
 
 exports[`test/optimization-level-2.ts > TAP > basic tests > makeRe +(?) 1`] = `

--- a/test/posix-class-with-comma.js
+++ b/test/posix-class-with-comma.js
@@ -1,0 +1,52 @@
+// Test for issue #273: Invalid regex generated when glob includes comma and character class
+// https://github.com/isaacs/minimatch/issues/273
+//
+// When a pattern includes both a comma (or other characters that were previously
+// escaped with backslash) and a POSIX character class (which requires the unicode
+// flag), the generated regex would be invalid because \, is not a valid escape
+// sequence in unicode regex mode.
+import t from 'tap'
+import { minimatch, Minimatch } from '../dist/esm/index.js'
+
+t.test('comma with POSIX character class should not throw', async t => {
+  // This was the original error case - should not throw SyntaxError
+  t.doesNotThrow(() => minimatch('foo', ',[[:space:]]'))
+  t.doesNotThrow(() => new Minimatch(',[[:space:]]'))
+
+  // Verify correct matching behavior
+  t.equal(minimatch('foo', ',[[:space:]]'), false, 'foo does not match ,[[:space:]]')
+  t.equal(minimatch(' ', ',[[:space:]]'), false, 'single space does not match (missing comma)')
+  t.equal(minimatch(', ', ',[[:space:]]'), true, 'comma-space matches')
+  t.equal(minimatch(',\t', ',[[:space:]]'), true, 'comma-tab matches')
+  t.equal(minimatch(',\n', ',[[:space:]]'), true, 'comma-newline matches')
+  t.equal(minimatch(',x', ',[[:space:]]'), false, 'comma-x does not match')
+})
+
+t.test('hash character with POSIX character class should not throw', async t => {
+  // Note: # is treated as comment by default, so we need nocomment: true
+  const opts = { nocomment: true }
+  t.doesNotThrow(() => minimatch('foo', '#[[:alpha:]]', opts))
+  t.equal(minimatch('#a', '#[[:alpha:]]', opts), true, 'hash-a matches')
+  t.equal(minimatch('#1', '#[[:alpha:]]', opts), false, 'hash-1 does not match')
+})
+
+t.test('space character with POSIX character class should not throw', async t => {
+  t.doesNotThrow(() => minimatch('foo', ' [[:digit:]]'))
+  t.equal(minimatch(' 5', ' [[:digit:]]'), true, 'space-5 matches')
+  t.equal(minimatch(' a', ' [[:digit:]]'), false, 'space-a does not match')
+})
+
+t.test('hyphen outside character class with POSIX class should not throw', async t => {
+  // Hyphen outside of character class in pattern
+  t.doesNotThrow(() => minimatch('foo', 'a-[[:lower:]]'))
+  t.equal(minimatch('a-b', 'a-[[:lower:]]'), true, 'a-b matches')
+  t.equal(minimatch('a-B', 'a-[[:lower:]]'), false, 'a-B does not match (uppercase)')
+})
+
+t.test('multiple special chars with POSIX class', async t => {
+  // Combination of comma, hash, space with POSIX class
+  t.doesNotThrow(() => minimatch('foo', ', #[[:alnum:]]'))
+  t.equal(minimatch(', #a', ', #[[:alnum:]]'), true, 'comma space hash a matches')
+  t.equal(minimatch(', #1', ', #[[:alnum:]]'), true, 'comma space hash 1 matches')
+  t.equal(minimatch(', #!', ', #[[:alnum:]]'), false, 'comma space hash ! does not match')
+})


### PR DESCRIPTION
## Summary

Fixes #273 - Invalid regex generated when glob includes comma and character class.

The `regExpEscape` function was escaping characters like `,`, `#`, `-`, and whitespace with backslash (e.g., `\,`). However, these escape sequences are invalid in unicode regex mode (`/u` flag).

When a pattern includes a POSIX character class like `[[:space:]]`, the unicode flag is required because POSIX classes use unicode property escapes (e.g., `\p{Z}`). This caused patterns like `,[[:space:]]` to throw:

```
SyntaxError: Invalid regular expression: /^\,[\p{Z}\t\r\n\v\f]$/u: Invalid escape
```

## Changes

- Modified `regExpEscape` in `src/ast.ts` to only escape characters that are both:
  1. Regex metacharacters (need escaping)
  2. Valid to escape in unicode mode

- Added comprehensive test suite in `test/posix-class-with-comma.js` covering:
  - Comma with POSIX character classes
  - Hash character with POSIX classes
  - Space character with POSIX classes
  - Hyphen outside character class with POSIX classes
  - Multiple special characters combined

## Test Plan

- [x] Reproduced the original issue - `minimatch('foo', ',[[:space:]]')` threw SyntaxError
- [x] Verified the fix resolves the issue - no longer throws
- [x] Verified correct matching behavior (comma-space matches, comma-x doesn't)
- [x] All existing tests pass (6249 total)
- [x] Updated snapshots for changed regex patterns (semantically equivalent)

Generated with [Claude Code](https://claude.ai/code)