### PR TITLE
Update brace-expansion dependency to version 5.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
   "type": "module",
   "module": "./dist/esm/index.js",
   "dependencies": {
-    "brace-expansion": "^5.0.5"
+    "brace-expansion": "^5.0.6"
   }
 }


### PR DESCRIPTION
Reason: [brace-expansion: Large numeric range defeats documented `max` DoS protection · CVE-2026-45149 · GitHub Advisory Database](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2)

Relates to https://github.com/isaacs/minimatch/issues/302