### PR TITLE
use public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "10.2.5",
   "repository": {
     "type": "git",
-    "url": "git@github.com:isaacs/minimatch"
+    "url": "https://github.com/isaacs/minimatch.git"
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",


### PR DESCRIPTION
## Summary

- update the package repository metadata from the SSH form to a public HTTPS GitHub URL
- keep the change limited to package metadata

## Validation

- `node -e "const p=require('./package.json'); if (p.repository.url !== 'https://github.com/isaacs/minimatch.git') process.exit(1)"`
- `git diff --check`
- `git ls-remote https://github.com/isaacs/minimatch.git HEAD`
- `npm run prepare`
- `npm pack --dry-run --json .`
- `npm test`
