### PR TITLE
fix: [:print:] class matches printable characters, not control

### DIFF
--- a/src/brace-expressions.ts
+++ b/src/brace-expressions.ts
@@ -12,7 +12,7 @@ const posixClasses: { [k: string]: [e: string, u: boolean, n?: boolean] } =
     '[:digit:]': ['\\p{Nd}', true],
     '[:graph:]': ['\\p{Z}\\p{C}', true, true],
     '[:lower:]': ['\\p{Ll}', true],
-    '[:print:]': ['\\p{C}', true],
+    '[:print:]': ['\\p{C}', true, true],
     '[:punct:]': ['\\p{P}', true],
     '[:space:]': ['\\p{Z}\\t\\r\\n\\v\\f', true],
     '[:upper:]': ['\\p{Lu}', true],

--- a/test/posix-class-print.ts
+++ b/test/posix-class-print.ts
@@ -1,0 +1,20 @@
+import t from 'tap'
+import { minimatch } from '../src/index.js'
+
+// [:print:] matches printable characters: everything except control
+// characters, including the space character. It is [:graph:] plus space.
+// Regression: [:print:] was translated to `[\p{C}]` (control characters)
+// instead of `[^\p{C}]`, so it matched only control characters and never
+// matched any printable character.
+t.equal(minimatch('a', '[[:print:]]'), true, 'letter is printable')
+t.equal(minimatch('Z', '[[:print:]]'), true, 'letter is printable')
+t.equal(minimatch('5', '[[:print:]]'), true, 'digit is printable')
+t.equal(minimatch(' ', '[[:print:]]'), true, 'space is printable')
+t.equal(minimatch('\t', '[[:print:]]'), false, 'tab is a control char, not printable')
+
+// [:graph:] is the sibling class: visible characters, excluding both space
+// and control characters. The only difference from [:print:] is the space.
+t.equal(minimatch('a', '[[:graph:]]'), true, 'letter is graphic')
+t.equal(minimatch('5', '[[:graph:]]'), true, 'digit is graphic')
+t.equal(minimatch(' ', '[[:graph:]]'), false, 'space is not graphic')
+t.equal(minimatch('\t', '[[:graph:]]'), false, 'tab is not graphic')


### PR DESCRIPTION
The `[:print:]` POSIX character class is translated to `[\p{C}]`, the set of control characters. Without a negation flag it matches control characters and never matches printable ones, so the result is inverted:

```js
minimatch('a', '[[:print:]]')     // false (should be true)
minimatch(' ', '[[:print:]]')     // false (should be true)
minimatch('\x01', '[[:print:]]')  // true  (should be false)
```

`[:print:]` should match every printable character, i.e. everything except control characters, including the space. The sibling `[:graph:]` class uses the same `\p{C}` exclusion and is already negated correctly (`['\\p{Z}\\p{C}', true, true]`); `[:print:]` is the only class that takes the `\p{C}` exclusion approach but is missing the negation flag.

The fix adds the flag so `[:print:]` becomes `[^\p{C}]`:

```diff
-    '[:print:]': ['\\p{C}', true],
+    '[:print:]': ['\\p{C}', true, true],
```

Added `test/posix-class-print.ts`. It fails on the current code (the printable assertions return false) and passes with the change. The full suite stays green; no existing tests or snapshots reference `[:print:]`.
