### PR TITLE
patch: Update brace-expansion from 1.1.7 to 1.1.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -386,9 +386,9 @@
       "dev": true
     },
     "balanced-match": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+      "version": "1.0.2",
+      "resolved": "https://flock-internal-npm-380235110861.d.codeartifact.us-east-1.amazonaws.com/npm/flock-internal-npm/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -412,11 +412,11 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+      "version": "1.1.18",
+      "resolved": "https://flock-internal-npm-380235110861.d.codeartifact.us-east-1.amazonaws.com/npm/flock-internal-npm/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "requires": {
-        "balanced-match": "^0.4.1",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -560,7 +560,7 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://flock-internal-npm-380235110861.d.codeartifact.us-east-1.amazonaws.com/npm/flock-internal-npm/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "convert-source-map": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": "*"
   },
   "dependencies": {
-    "brace-expansion": "^1.1.7"
+    "brace-expansion": "^1.1.17"
   },
   "devDependencies": {
     "tap": "^15.1.6"


### PR DESCRIPTION
I have a project with transitive dependencies on minimatch v3, v9, and v10.  I'm getting npm audit complaints over the minimatch versions, so just specifying which brace-expansion version to use for the various minimatch versions in my overrides doesn't clean the noise out of the audit output.

The backported fixed versions are 1.1.17+, 2.1.3+, 3.0.3+, and 5.0.8+: https://github.com/juliangruber/brace-expansion/issues/142#issue-5012029402

If this PR is ok, I also have branches I can PR for v4, v5, v6, v7, v8, v9, and an update in main for 5.0.8 to 5.0.9, but I didn't want to flood you with PRs without getting some feedback first in case.